### PR TITLE
Fix dep-on-root composer ci issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           coverage: pcov
 
       - name: Install dependencies
-        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+        run: COMPOSER_ROOT_VERSION=dev-master composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: ./vendor/bin/phpunit --coverage-clover clover.xml


### PR DESCRIPTION
See https://getcomposer.org/doc/articles/troubleshooting.md#dependencies-on-the-root-package

Only seems to affect CI:

```
Run composer update --prefer-stable --prefer-dist --no-interaction --no-progress
Loading composer repositories with package information
Info from [https://repo.packagist.org:](https://repo.packagist.org/) #StandWithUkraine
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires bytestream/horde-mime ^2.12 -> satisfiable by bytestream/horde-mime[v2.12.0, 2.x-dev].
    - bytestream/horde-mime[v2.12.0, ..., 2.x-dev] require bytestream/horde-mail ^2.7 -> satisfiable by bytestream/horde-mail[dev-master, v2.7.0, 2.x-dev (alias of dev-master)] from composer repo (https://repo.packagist.org/) but bytestream/horde-mail is the root package and cannot be modified. See https://getcomposer.org/dep-on-root for details and assistance.
```